### PR TITLE
Add hover metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "html2md"
 version = "0.2.15"
-source = "git+https://gitlab.com/o0Frederik0o/html2md#a50c50b5b98d4360257002b23d967471001ef0df"
+source = "git+https://gitlab.com/o0Frederik0o/html2md.git#a50c50b5b98d4360257002b23d967471001ef0df"
 dependencies = [
  "html5ever",
  "jni",

--- a/crates/info-provider/src/api.rs
+++ b/crates/info-provider/src/api.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::{BTreeSet, HashMap, HashSet},
     sync::Arc,
 };
@@ -78,18 +79,18 @@ impl InfoProvider {
         }
     }
 
-    pub async fn get_crate_repository_api(&self, crate_name: &str) -> Option<String> {
+    pub async fn get_crate_metadata_api(&self, crate_name: &str) -> Result<Crate, anyhow::Error> {
         let url = format!("https://crates.io/api/v1/crates/{}", crate_name);
 
-        let response = self
+        Ok(self
             .client
             .get(&url)
             .header(USER_AGENT, "zed")
             .send()
-            .await
-            .ok()?;
-        let json: serde_json::Value = response.json().await.ok()?;
-        json["crate"]["repository"].as_str().map(|s| s.to_string())
+            .await?
+            .json::<SingleCrateResponse>()
+            .await?
+            .crate_metadata)
     }
 
     pub async fn get_info_cache_api(
@@ -267,13 +268,32 @@ pub struct Crate {
     pub exact_match: bool,
     pub name: String,
     pub description: Option<String>,
+    pub homepage: Option<String>,
+    pub documentation: Option<String>,
+    pub repository: Option<String>,
     pub max_stable_version: Option<String>,
     pub max_version: Option<String>,
+}
+
+impl Crate {
+    /// Returns documentation URL when set, otherwise falls back to docs.rs
+    pub fn documentation_url(&self) -> Cow<'_, str> {
+        self.documentation
+            .as_deref()
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Owned(format!("https://docs.rs/{}", self.name)))
+    }
 }
 
 #[derive(Serialize, Deserialize)]
 struct SearchResponse {
     crates: Vec<Crate>,
+}
+
+#[derive(Deserialize)]
+struct SingleCrateResponse {
+    #[serde(rename = "crate")]
+    crate_metadata: Crate,
 }
 
 async fn info(

--- a/crates/info-provider/src/lib.rs
+++ b/crates/info-provider/src/lib.rs
@@ -96,8 +96,19 @@ impl InfoProvider {
         self.search_api(name).await
     }
 
-    pub async fn get_crate_repository(&self, crate_name: &str) -> Option<String> {
-        self.get_crate_repository_api(crate_name).await
+    pub async fn get_crate_metadata(&self, crate_name: &str) -> Result<Crate, anyhow::Error> {
+        let offline = *self.offline.read().await;
+        if offline {
+            let len = self.data.read().await.1.len();
+            if len != 0 {
+                let offline_crate = self
+                    .get_local(crate_name)
+                    .await
+                    .ok_or(anyhow::anyhow!("Crate is not found: {}", crate_name))?;
+                return Ok(offline_crate.as_crate(true));
+            }
+        }
+        self.get_crate_metadata_api(crate_name).await
     }
 }
 

--- a/crates/info-provider/src/local.rs
+++ b/crates/info-provider/src/local.rs
@@ -18,15 +18,7 @@ impl InfoProvider {
         let lock = self.data.read().await;
         let mut v = search(name, &lock.0, &lock.1);
         v.sort_by(|a, b| b.order.cmp(&a.order));
-        v.into_iter()
-            .map(|v| Crate {
-                exact_match: v.name == name,
-                name: v.name.clone(),
-                description: v.description.clone(),
-                max_stable_version: v.latest_stable_version.clone(),
-                max_version: v.latest_version.clone().or(v.latest_stable_version.clone()),
-            })
-            .collect()
+        v.into_iter().map(|v| v.as_crate(v.name == name)).collect()
     }
 
     pub async fn get_local(&self, name: &str) -> Option<Arc<OfflineCrate>> {
@@ -354,6 +346,23 @@ impl OfflineCrate {
             documentation,
             latest_stable_version,
             latest_version,
+        }
+    }
+
+    pub fn as_crate(&self, exact_match: bool) -> Crate {
+        Crate {
+            exact_match,
+            name: self.name.clone(),
+            description: self.description.clone(),
+            homepage: self.homepage.clone(),
+            documentation: self.documentation.clone(),
+            repository: self.repository.clone(),
+            max_stable_version: self.latest_stable_version.clone(),
+            max_version: self
+                .latest_version
+                .as_ref()
+                .or(self.latest_stable_version.as_ref())
+                .cloned(),
         }
     }
 }

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -273,7 +273,7 @@ impl LanguageServer for Context {
                 }
                 let version = &value.value.data;
 
-                let crate_name = &dep.data.crate_name();
+                let crate_name = dep.data.crate_name();
 
                 let open_page =
                     |actions_last: &mut Vec<CodeActionOrCommand>, name, url: &String| {
@@ -316,7 +316,7 @@ impl LanguageServer for Context {
                             title: "Open Source".to_string(),
                             command: "open-src".to_string(),
                             arguments: Some(vec![
-                                serde_json::Value::String(crate_name.clone()),
+                                serde_json::Value::String(crate_name.to_owned()),
                                 serde_json::Value::String(version.clone()),
                             ]),
                         }),

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -414,7 +414,11 @@ impl LanguageServer for Context {
             let name = params.arguments.get(0).and_then(|arg| arg.as_str());
             let version = params.arguments.get(1).and_then(|arg| arg.as_str());
             let mut src = if let Some(name) = name {
-                self.info.get_crate_repository(name).await
+                self.info
+                    .get_crate_metadata(name)
+                    .await
+                    .ok()
+                    .and_then(|metadata| metadata.repository)
             } else {
                 None
             };

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -275,31 +275,30 @@ impl LanguageServer for Context {
 
                 let crate_name = dep.data.crate_name();
 
-                let open_page =
-                    |actions_last: &mut Vec<CodeActionOrCommand>, name, url: &String| {
-                        let action = CodeAction {
+                let open_page = |actions_last: &mut Vec<CodeActionOrCommand>, name, url: String| {
+                    let action = CodeAction {
+                        title: format!("Open {name}"),
+                        kind: Some(CodeActionKind::EMPTY),
+                        command: Some(Command {
                             title: format!("Open {name}"),
-                            kind: Some(CodeActionKind::EMPTY),
-                            command: Some(Command {
-                                title: format!("Open {name}"),
-                                command: "open_url".to_string(),
-                                arguments: Some(vec![serde_json::Value::String(url.clone())]),
-                            }),
-                            ..CodeAction::default()
-                        };
-                        actions_last.push(CodeActionOrCommand::CodeAction(action));
+                            command: "open_url".to_string(),
+                            arguments: Some(vec![serde_json::Value::String(url)]),
+                        }),
+                        ..CodeAction::default()
                     };
+                    actions_last.push(CodeActionOrCommand::CodeAction(action));
+                };
 
                 if lock.config.offline {
                     let info = self.info.get_local(crate_name).await;
                     if let Some(info) = info {
-                        if let Some(repo) = &info.repository {
+                        if let Some(repo) = info.repository.clone() {
                             open_page(&mut actions_last, "Repository", repo);
                         }
-                        if let Some(documentation) = &info.documentation {
+                        if let Some(documentation) = info.documentation.clone() {
                             open_page(&mut actions_last, "Documentation", documentation);
                         }
-                        if let Some(homepage) = &info.homepage {
+                        if let Some(homepage) = info.homepage.clone() {
                             open_page(&mut actions_last, "Homepage", homepage);
                         }
                     }
@@ -307,7 +306,7 @@ impl LanguageServer for Context {
                     open_page(
                         &mut actions_last,
                         "Documentation",
-                        &format!("https://docs.rs/{crate_name}/{version}/"),
+                        format!("https://docs.rs/{crate_name}/{version}/"),
                     );
                     let action = CodeAction {
                         title: "Open Source".to_string(),
@@ -327,7 +326,7 @@ impl LanguageServer for Context {
                 open_page(
                     &mut actions_last,
                     "crates.io",
-                    &format!("https://crates.io/crates/{crate_name}"),
+                    format!("https://crates.io/crates/{crate_name}"),
                 );
             } else if let DepSource::Workspace(range) = &dep.data.source {
                 let workspace_uri = lock.get_workspace(&uri);

--- a/crates/parser/src/analyze.rs
+++ b/crates/parser/src/analyze.rs
@@ -98,7 +98,7 @@ impl Db {
                     CacheItemOut::NotStarted => {
                         let info = self.info.clone();
                         let reg = registry.as_ref().map(|v| v.value.data.to_string());
-                        let name = toml.data.crate_name();
+                        let name = toml.data.crate_name().to_owned();
                         let uri = uri.clone();
                         let sel = self.sel.clone().unwrap();
                         if !workspace {

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -149,7 +149,7 @@ impl Db {
         }
         let lock = self.locks.get(&root_file)?;
         let packges = lock.packages();
-        let extract = |id: String| packges.get(&id)?.first();
+        let extract = |id: &str| packges.get(id)?.first();
         let data = toml
             .dependencies
             .iter()

--- a/crates/parser/src/toml.rs
+++ b/crates/parser/src/toml.rs
@@ -86,12 +86,11 @@ pub struct Dependency {
 }
 
 impl Dependency {
-    pub fn crate_name(&self) -> String {
+    pub fn crate_name(&self) -> &str {
         self.package
             .as_ref()
             .map(|v| &v.data)
             .unwrap_or(&self.name.data)
-            .to_owned()
     }
 
     pub fn set_name(&mut self, name: String) {


### PR DESCRIPTION
Here is a draft PR for links on hover.
<img width="352" height="519" alt="Screenshot 2025-07-20 at 14 00 38" src="https://github.com/user-attachments/assets/85154106-73b4-4a46-8396-d2be795775ee" />

Please have a look and share your feedback.

## Changes

- Add links to docs, homepage, repo in the hover popup
- Minor improvements to memory ownership with preference to borrow when possible and let call-site clone data when necessary

## Further thoughts

It seems excessive that we need to query crates.io on hover. It would make sense to introduce some sort of transparent cache that would prevent querying crates.io on each hover. 

It seems that offline mode is made for that but then it's only enabled via some sort of setting if I understood that right.